### PR TITLE
Polish

### DIFF
--- a/src/main/java/net/kemitix/mon/Functor.java
+++ b/src/main/java/net/kemitix/mon/Functor.java
@@ -24,9 +24,16 @@ package net.kemitix.mon;
 import java.util.function.Function;
 
 /**
- * The Functor interface.
+ * The Functor is used for types that can be mapped over.
  *
- * @param <T> the type of the functor content
+ * <p>Implementations of Functor should satisfy the following laws:</p>
+ *
+ * <ul>
+ *     <li>map id  ==  id</li>
+ *     <li>map (f . g)  ==  map f . map g</li>
+ * </ul>
+ *
+ * @param <T> the type of the Functor
  *
  * @author Tomasz Nurkiewicz (?@?.?)
  */

--- a/src/main/java/net/kemitix/mon/Functor.java
+++ b/src/main/java/net/kemitix/mon/Functor.java
@@ -33,12 +33,12 @@ import java.util.function.Function;
 public interface Functor<T> {
 
     /**
-     * Map the content of the functor through the function.
+     * Applies the function to the value within the Functor, returning the result within a Functor.
      *
-     * @param f   the function
-     * @param <R> the type the functor maps to
+     * @param f   the function to apply
+     * @param <R> the type of the result of the function
      *
-     * @return the new functor
+     * @return a Functor containing the result of the function {@code f} applied to the value
      */
     <R> Functor<R> map(Function<T, R> f);
 }

--- a/src/main/java/net/kemitix/mon/Mon.java
+++ b/src/main/java/net/kemitix/mon/Mon.java
@@ -82,16 +82,8 @@ public class Mon<T> implements Functor<T> {
         return new Mon<>(v);
     }
 
-    /**
-     * Applies the function to the value within the Mon, returning a Mon containing the result.
-     *
-     * @param f   the function to apply
-     * @param <R> the type of the result of the function
-     *
-     * @return a Mon containing the result of the function {@code f} to the value
-     */
     @Override
-    public <R> Mon<R> map(final Function<T, R> f) {
+    public final <R> Mon<R> map(final Function<T, R> f) {
         return Mon.of(f.apply(value));
     }
 
@@ -104,7 +96,7 @@ public class Mon<T> implements Functor<T> {
      *
      * @return a Mon containing the result of the function
      */
-    public <R> Mon<R> flatMap(final Function<T, Mon<R>> f) {
+    public final <R> Mon<R> flatMap(final Function<T, Mon<R>> f) {
         return f.apply(value);
     }
 

--- a/src/main/java/net/kemitix/mon/TypeAlias.java
+++ b/src/main/java/net/kemitix/mon/TypeAlias.java
@@ -47,7 +47,6 @@ public abstract class TypeAlias<T> {
         this.value = value;
     }
 
-
     /**
      * Map the TypeAlias into another value.
      *
@@ -56,7 +55,7 @@ public abstract class TypeAlias<T> {
      *
      * @return a TypeAlias
      */
-    public <R> R map(final Function<T, R> f) {
+    public final <R> R map(final Function<T, R> f) {
         return f.apply(value);
     }
 

--- a/src/main/java/net/kemitix/mon/TypeAlias.java
+++ b/src/main/java/net/kemitix/mon/TypeAlias.java
@@ -21,6 +21,8 @@
 
 package net.kemitix.mon;
 
+import java.util.function.Function;
+
 /**
  * Type Alias for other types.
  *
@@ -43,6 +45,19 @@ public abstract class TypeAlias<T> {
      */
     protected TypeAlias(final T value) {
         this.value = value;
+    }
+
+
+    /**
+     * Map the TypeAlias into another value.
+     *
+     * @param f   the function to create the new value
+     * @param <R> the type of the new value
+     *
+     * @return a TypeAlias
+     */
+    public <R> R map(final Function<T, R> f) {
+        return f.apply(value);
     }
 
     @Override
@@ -71,5 +86,4 @@ public abstract class TypeAlias<T> {
     public final T getValue() {
         return value;
     }
-
 }

--- a/src/main/java/net/kemitix/mon/TypeAlias.java
+++ b/src/main/java/net/kemitix/mon/TypeAlias.java
@@ -83,7 +83,7 @@ public abstract class TypeAlias<T> {
      *
      * @return the value
      */
-    public final T getValue() {
+    public T getValue() {
         return value;
     }
 }

--- a/src/test/java/net/kemitix/mon/IdentityTest.java
+++ b/src/test/java/net/kemitix/mon/IdentityTest.java
@@ -11,6 +11,15 @@ import org.junit.Test;
 public class IdentityTest implements WithAssertions {
 
     @Test
+    public void functorLawMapIdEqualsId() {
+        //given
+        final String id = "id";
+        //when
+
+        //then
+    }
+
+    @Test
     public void canMapIdentityFromStringToInteger() {
         //given
         final Identity<String> idString = new Identity<>("abc");
@@ -18,6 +27,10 @@ public class IdentityTest implements WithAssertions {
         final Identity<Integer> idInt = idString.map(String::length);
         //then
         assertIdentityContains(idInt, 3);
+    }
+
+    private <T> void assertIdentityContains(final Identity<T> identity, final T expected) {
+        identity.map(id -> assertThat(id).isEqualTo(expected));
     }
 
     @Test
@@ -32,10 +45,6 @@ public class IdentityTest implements WithAssertions {
                                                                  .map(String::getBytes);
         //then
         assertIdentityContains(idBytes, "par".getBytes());
-    }
-
-    private <T> void assertIdentityContains(final Identity<T> identity, final T expected) {
-        identity.map(id -> assertThat(id).isEqualTo(expected));
     }
 
 }

--- a/src/test/java/net/kemitix/mon/MonTest.java
+++ b/src/test/java/net/kemitix/mon/MonTest.java
@@ -18,6 +18,13 @@ public class MonTest {
         assertMonContains(wrap, "test");
     }
 
+    private <T> void assertMonContains(
+            final Mon<T> wrap,
+            final T expected
+                                      ) {
+        wrap.map(value -> assertThat(value).isEqualTo(expected));
+    }
+
     @Test
     public void canMap() {
         //given
@@ -143,9 +150,5 @@ public class MonTest {
         assertThat(one).isEqualTo(otherOne);
         assertThat(one).isNotEqualTo(notAMon);
         assertThat(one).isNotEqualTo(null);
-    }
-
-    private <T> void assertMonContains(final Mon<T> wrap, final T expected) {
-        wrap.map(value -> assertThat(value).isEqualTo(expected));
     }
 }

--- a/src/test/java/net/kemitix/mon/TypeAliasTest.java
+++ b/src/test/java/net/kemitix/mon/TypeAliasTest.java
@@ -2,6 +2,8 @@ package net.kemitix.mon;
 
 import org.junit.Test;
 
+import java.util.function.Function;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TypeAliasTest {
@@ -59,8 +61,21 @@ public class TypeAliasTest {
     public void shouldHaveSameToStringAsAliasedType() throws Exception {
         //given
         final String value = "value";
+        //when
         final AnAlias anAlias = AnAlias.of(value);
+        //then
         assertThat(anAlias.toString()).isEqualTo(value);
+    }
+
+    @Test
+    public void shouldMapTypeAlias() {
+        //given
+        final AnAlias anAlias = AnAlias.of("text");
+        final Function<String, String> function = v -> v;
+        //when
+        final String value = anAlias.map(function);
+        //then
+        assertThat(value).isEqualTo("text");
     }
 
     private static class AnAlias extends TypeAlias<String> {


### PR DESCRIPTION
`TypeAlias`:
* `map()` added
* `getValue()` is no longer final - allows TypeAliases of mutable objects to provide safe copies

`Mon`:
* `.map()` and `.flatMap()` are now `final`