### PR TITLE
Remove getValue() from TypeAlias public API

### DIFF
--- a/src/main/java/net/kemitix/mon/TypeAlias.java
+++ b/src/main/java/net/kemitix/mon/TypeAlias.java
@@ -38,13 +38,20 @@ public abstract class TypeAlias<T> {
      */
     private final T value;
 
+    private final Class<? super T> type;
+
     /**
      * Constructor.
      *
      * @param value the value
+     * @param type  the type of the value
      */
-    protected TypeAlias(final T value) {
+    protected TypeAlias(
+            final T value,
+            final Class<? super T> type
+                       ) {
         this.value = value;
+        this.type = type;
     }
 
     /**
@@ -56,31 +63,37 @@ public abstract class TypeAlias<T> {
      * @return a TypeAlias
      */
     public final <R> R map(final Function<T, R> f) {
-        return f.apply(value);
+        return f.apply(getValue());
     }
 
     @Override
     public final int hashCode() {
-        return value.hashCode();
+        return getValue().hashCode();
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public final boolean equals(final Object o) {
         if (o instanceof TypeAlias) {
-            return value.equals(((TypeAlias) o).value);
+            if (((TypeAlias) o).type.equals(type)) {
+                return ((TypeAlias<T>) o).map(getValue()::equals);
+            } else {
+                return false;
+            }
         }
-        return value.equals(o);
+        return map(o::equals);
     }
 
     @Override
     public final String toString() {
-        return value.toString();
+        return getValue().toString();
     }
 
     /**
      * Get the value of the type alias.
      *
      * @return the value
+     *
      * @deprecated try using {@link #map(Function)}
      */
     @Deprecated

--- a/src/main/java/net/kemitix/mon/TypeAlias.java
+++ b/src/main/java/net/kemitix/mon/TypeAlias.java
@@ -81,7 +81,9 @@ public abstract class TypeAlias<T> {
      * Get the value of the type alias.
      *
      * @return the value
+     * @deprecated try using {@link #map(Function)}
      */
+    @Deprecated
     public T getValue() {
         return value;
     }

--- a/src/main/java/net/kemitix/mon/TypeAlias.java
+++ b/src/main/java/net/kemitix/mon/TypeAlias.java
@@ -93,11 +93,8 @@ public abstract class TypeAlias<T> {
      * Get the value of the type alias.
      *
      * @return the value
-     *
-     * @deprecated try using {@link #map(Function)}
      */
-    @Deprecated
-    public T getValue() {
+    private T getValue() {
         return value;
     }
 }

--- a/src/test/java/net/kemitix/mon/TypeAliasTest.java
+++ b/src/test/java/net/kemitix/mon/TypeAliasTest.java
@@ -2,6 +2,7 @@ package net.kemitix.mon;
 
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,10 +14,26 @@ public class TypeAliasTest {
         //given
         final String value = "value";
         //when
-        final TypeAlias<String> typeAlias = new TypeAlias<String>(value) {
-        };
+        final TypeAlias<String> typeAlias = givenTypeAlias(value);
         //then
         assertThat(typeAlias.<Boolean>map(value::equals)).isTrue();
+    }
+
+    @Test
+    public void shouldCreateATypeAliasWithNestedGenericTypes() {
+        //given
+        final Iterable<String> iterable = Collections.emptyList();
+        //when
+        final TypeAlias<Iterable<String>> typeAlias =
+                new TypeAlias<Iterable<String>>(iterable, Iterable.class) {
+        };
+        //then
+        assertThat(typeAlias.<Boolean>map(iterable::equals)).isTrue();
+    }
+
+    private TypeAlias<String> givenTypeAlias(final String value) {
+        return new TypeAlias<String>(value, String.class) {
+        };
     }
 
     @Test
@@ -27,6 +44,15 @@ public class TypeAliasTest {
         final AnAlias anAlias = AnAlias.of(value);
         //then
         assertThat(anAlias.<Boolean>map(value::equals)).isTrue();
+    }
+
+    @Test
+    public void shouldNotBeEqualWhenValueTypesAreDifferent() {
+        //given
+        final TypeAlias<String> stringTypeAlias = givenTypeAlias("1");
+        final TypeAlias<Integer> integerTypeAlias = new TypeAlias<Integer>(1, Integer.class){};
+        //then
+        assertThat(stringTypeAlias).isNotEqualTo(integerTypeAlias);
     }
 
     @Test
@@ -86,7 +112,7 @@ public class TypeAliasTest {
          * @param value the value
          */
         protected AnAlias(final String value) {
-            super(value);
+            super(value, String.class);
         }
 
         protected static AnAlias of(final String value) {

--- a/src/test/java/net/kemitix/mon/TypeAliasTest.java
+++ b/src/test/java/net/kemitix/mon/TypeAliasTest.java
@@ -16,7 +16,7 @@ public class TypeAliasTest {
         final TypeAlias<String> typeAlias = new TypeAlias<String>(value) {
         };
         //then
-        assertThat(typeAlias.getValue()).isEqualTo(value);
+        assertThat(typeAlias.<Boolean>map(value::equals)).isTrue();
     }
 
     @Test
@@ -26,7 +26,7 @@ public class TypeAliasTest {
         //when
         final AnAlias anAlias = AnAlias.of(value);
         //then
-        assertThat(anAlias.getValue()).isEqualTo(value);
+        assertThat(anAlias.<Boolean>map(value::equals)).isTrue();
     }
 
     @Test


### PR DESCRIPTION
Use the `map()` method instead. A hack to emulate `getValue()` would be `.map(Function.identity())`.