### PR TITLE
BeanBuilder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <tiles-maven-plugin.version>2.10</tiles-maven-plugin.version>
         <kemitix-tiles.version>0.1.1</kemitix-tiles.version>
         <digraph-dependency.basePackage>net.kemitix.mon</digraph-dependency.basePackage>
+        <kemitix-checkstyle.version>4.0.1</kemitix-checkstyle.version>
     </properties>
 
     <dependencies>
@@ -53,6 +54,7 @@
                 <configuration>
                     <tiles>
                         <tile>net.kemitix.tiles:all-tiles:${kemitix-tiles.version}</tile>
+                        <tile>net.kemitix.checkstyle:tile:${kemitix-checkstyle.version}</tile>
                     </tiles>
                 </configuration>
             </plugin><!-- tiles-maven-plugin -->

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
     <version>0.5.0-SNAPSHOT</version>
 
     <properties>
+        <java.version>1.8</java.version>
         <junit.version>4.12</junit.version>
         <assertj-core.version>3.8.0</assertj-core.version>
         <lombok.version>1.16.18</lombok.version>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <assertj-core.version>3.8.0</assertj-core.version>
         <lombok.version>1.16.18</lombok.version>
         <tiles-maven-plugin.version>2.10</tiles-maven-plugin.version>
-        <kemitix-tiles.version>0.1.1</kemitix-tiles.version>
+        <kemitix-tiles.version>0.5.2</kemitix-tiles.version>
         <digraph-dependency.basePackage>net.kemitix.mon</digraph-dependency.basePackage>
         <kemitix-checkstyle.version>4.0.1</kemitix-checkstyle.version>
     </properties>
@@ -53,7 +53,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <tiles>
-                        <tile>net.kemitix.tiles:all-tiles:${kemitix-tiles.version}</tile>
+                        <tile>net.kemitix.tiles:all:${kemitix-tiles.version}</tile>
                         <tile>net.kemitix.checkstyle:tile:${kemitix-checkstyle.version}</tile>
                     </tiles>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.kemitix</groupId>
         <artifactId>kemitix-parent</artifactId>
-        <version>5.0.3</version>
+        <version>5.1.0</version>
         <relativePath/>
     </parent>
     <artifactId>mon</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,8 @@
         <lombok.version>1.16.18</lombok.version>
         <tiles-maven-plugin.version>2.10</tiles-maven-plugin.version>
         <kemitix-tiles.version>0.5.2</kemitix-tiles.version>
+        <!-- kemitix-tiles provides surefire 2.20.1 which is broken - downgrade surefire to 2.20 -->
+        <maven-surefire-plugin.version>2.20</maven-surefire-plugin.version>
         <digraph-dependency.basePackage>net.kemitix.mon</digraph-dependency.basePackage>
         <kemitix-checkstyle.version>4.0.1</kemitix-checkstyle.version>
     </properties>

--- a/src/main/java/net/kemitix/mon/BeanBuilder.java
+++ b/src/main/java/net/kemitix/mon/BeanBuilder.java
@@ -1,0 +1,22 @@
+package net.kemitix.mon;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+@RequiredArgsConstructor
+public class BeanBuilder<T> {
+
+    private final Supplier<T> supplier;
+
+    public static <T> BeanBuilder<T> define(final Supplier<T> supplier) {
+        return new BeanBuilder<>(supplier);
+    }
+
+    public T with(final Consumer<T> consumer) {
+        final T result = supplier.get();
+        consumer.accept(result);
+        return result;
+    }
+}

--- a/src/main/java/net/kemitix/mon/BeanBuilder.java
+++ b/src/main/java/net/kemitix/mon/BeanBuilder.java
@@ -1,3 +1,24 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Paul Campbell
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies
+ * or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
+ * AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package net.kemitix.mon;
 
 import lombok.RequiredArgsConstructor;
@@ -5,18 +26,36 @@ import lombok.RequiredArgsConstructor;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+/**
+ * Helper to create bean-style objects.
+ *
+ * @param <T> The type of the bean being built
+ */
 @RequiredArgsConstructor
 public class BeanBuilder<T> {
 
     private final Supplier<T> supplier;
 
-    public static <T> BeanBuilder<T> define(final Supplier<T> supplier) {
-        return new BeanBuilder<>(supplier);
+    /**
+     * Create a BeanBuilder from the Supplier.
+     *
+     * @param constructor supplies a new instance of the bean
+     * @param <T> the type of the bean being built
+     * @return a BeanBuilder instance
+     */
+    public static <T> BeanBuilder<T> define(final Supplier<T> constructor) {
+        return new BeanBuilder<>(constructor);
     }
 
-    public T with(final Consumer<T> consumer) {
+    /**
+     * Creates a new bean and passes it to the customiser.
+     *
+     * @param customiser customises the template bean
+     * @return the final customised bean
+     */
+    public T with(final Consumer<T> customiser) {
         final T result = supplier.get();
-        consumer.accept(result);
+        customiser.accept(result);
         return result;
     }
 }

--- a/src/test/java/net/kemitix/mon/BeanBuilderTest.java
+++ b/src/test/java/net/kemitix/mon/BeanBuilderTest.java
@@ -1,0 +1,42 @@
+package net.kemitix.mon;
+
+import static net.kemitix.mon.BeanBuilder.define;
+import static org.assertj.core.api.Assertions.*;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.junit.Test;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public class BeanBuilderTest {
+
+    @Test
+    public void canCreateAndSetupObject() {
+        //given
+        final Supplier<DataObject> templateSupplier = () -> new DataObject("name");
+        final Consumer<DataObject> propertySetter = data -> data.setValue("value");
+
+        //when
+        final DataObject result = define(templateSupplier)
+                .with(propertySetter);
+
+        //then
+        assertThat(result)
+                .returns("name", DataObject::getName)
+                .returns("value", DataObject::getValue);
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    private class DataObject {
+
+        private final String name;
+
+        @Setter
+        private String value;
+
+    }
+}


### PR DESCRIPTION
Experimental class for building and initialising bean-style objects.

```java
@Bean
BeanObject beanObject() {
    BeanObject bean = new BeanObject("name");
    bean.setValue("value");
    bean.setType("type");
    return bean;
}
```

Becomes:
```java
@Bean
BeanObject beanObject() {
    return BeanBuilder.define(() -> new BeanObject("name"))
        .with(bean -> {
            bean.setValue("value");
            bean.setType("type");
        });
}
```

No-one is claiming it is more concise.