### PR TITLE
Update sonatype-release trigger

### DIFF
--- a/.github/workflows/sonatype-deploy.yml
+++ b/.github/workflows/sonatype-deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to Sonatype Nexus
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   deploy:


### PR DESCRIPTION
Switching to using release drafter means the Releases are created early but in a draft mode. This somehow doesn't trigger this action, which was a good thing. However, when the release was published it didn't trigger the workflow, meaning the release wasn't published.