### PR TITLE
Remove Deprecated methods

### DIFF
--- a/src/main/java/net/kemitix/mon/result/Err.java
+++ b/src/main/java/net/kemitix/mon/result/Err.java
@@ -24,7 +24,6 @@ package net.kemitix.mon.result;
 import lombok.RequiredArgsConstructor;
 
 import java.util.Objects;
-import java.util.concurrent.Callable;
 import java.util.function.BinaryOperator;
 import java.util.function.Consumer;
 import java.util.function.Function;

--- a/src/main/java/net/kemitix/mon/result/Err.java
+++ b/src/main/java/net/kemitix/mon/result/Err.java
@@ -123,11 +123,6 @@ class Err<T> implements Result<T> {
     }
 
     @Override
-    public <R> Result<R> andThen(final Function<T, Callable<R>> f) {
-        return (Result<R>) this;
-    }
-
-    @Override
     public Result<T> thenWith(final Function<T, WithResultContinuation<T>> f) {
         return this;
     }

--- a/src/main/java/net/kemitix/mon/result/Result.java
+++ b/src/main/java/net/kemitix/mon/result/Result.java
@@ -739,29 +739,6 @@ public interface Result<T> extends BaseResult, ThrowableFunctor<T, ThrowableFunc
     );
 
     /**
-     * Maps a Success Result to another Result using a Callable that is able to throw a checked exception.
-     *
-     * <p>Combination of {@link #flatMap(Function)} and {@link #of(Callable)}.</p>
-     *
-     * <pre><code>
-     * Integer doSomething() {...}
-     * String doSomethingElse(final Integer value) {...}
-     * Result&lt;String&gt; r = Result.of(() -&gt; doSomething())
-     *                          .andThen(value -&gt; () -&gt; doSomethingElse(value));
-     * </code></pre>
-     *
-     * <p>When the Result is an Err, then the original error is carried over and the Callable is never called.</p>
-     *
-     * @param f   the function to map the Success value into the Callable
-     * @param <R> the type of the final Result
-     * @return a new Result
-     * @deprecated Use {@link #map(ThrowableFunction)}
-     */
-    @API(status = DEPRECATED)
-    @Deprecated
-    <R> Result<R> andThen(Function<T, Callable<R>> f);
-
-    /**
      * Perform the continuation with the value within the success {@code Result}
      * and return itself.
      *

--- a/src/main/java/net/kemitix/mon/result/Result.java
+++ b/src/main/java/net/kemitix/mon/result/Result.java
@@ -447,23 +447,6 @@ public interface Result<T> extends BaseResult, ThrowableFunctor<T, ThrowableFunc
     }
 
     /**
-     * Swaps the inner {@code Result} of a {@link Maybe}, so that a {@code Result} contains a {@code Maybe}.
-     *
-     * @param maybeResult the Maybe the contains a Result
-     * @param <T>         the type of the value that may be in the Result
-     * @return a Result containing a Maybe, the value in the Maybe was the value in a successful Result within the
-     * original Maybe. If the original Maybe is Nothing, the Result will contain Nothing. If the original Result was an
-     * error, then the Result will also be an error.
-     * @deprecated
-     */
-    @API(status = DEPRECATED)
-    @Deprecated
-    static <T> Result<Maybe<T>> swap(final Maybe<Result<T>> maybeResult) {
-        return maybeResult.orElseGet(() -> Result.ok(null))
-                .flatMap(value -> Result.ok(Maybe.maybe(value)));
-    }
-
-    /**
      * Creates a {@link Maybe} from the {@code Result}.
      *
      * <p>Where the {@code Result} is a {@link Success}, the {@code Maybe} will be a {@code Just} contain the value of

--- a/src/main/java/net/kemitix/mon/result/Success.java
+++ b/src/main/java/net/kemitix/mon/result/Success.java
@@ -111,11 +111,6 @@ class Success<T> implements Result<T> {
     }
 
     @Override
-    public <R> Result<R> andThen(final Function<T, Callable<R>> f) {
-        return result(f.apply(value));
-    }
-
-    @Override
     public Result<T> thenWith(final Function<T, WithResultContinuation<T>> f) {
         return f.apply(value).call(this);
     }

--- a/src/main/java/net/kemitix/mon/result/Success.java
+++ b/src/main/java/net/kemitix/mon/result/Success.java
@@ -24,7 +24,6 @@ package net.kemitix.mon.result;
 import lombok.RequiredArgsConstructor;
 
 import java.util.Objects;
-import java.util.concurrent.Callable;
 import java.util.function.BinaryOperator;
 import java.util.function.Consumer;
 import java.util.function.Function;

--- a/src/test/java/net/kemitix/mon/ResultTest.java
+++ b/src/test/java/net/kemitix/mon/ResultTest.java
@@ -1610,6 +1610,64 @@ class ResultTest implements WithAssertions {
 
     }
 
+    @Nested
+    @DisplayName("andThen")
+    class AndThenTests {
+
+        @Test
+        void successVoid_andThen_returnSelf() {
+            //given
+            ResultVoid ok = Result.ok();
+            //when
+            ResultVoid result = ok.andThen(() -> {});
+            //then
+            assertThat(result).isSameAs(ok);
+        }
+
+        @Test
+        void successVoid_andThen_isCalled() {
+            //given
+            ResultVoid ok = Result.ok();
+            AtomicBoolean called = new AtomicBoolean(false);
+            //when
+            ok.andThen(() -> called.set(true));
+            //then
+            assertThat(called).isTrue();
+        }
+
+        @Test
+        void successVoid_andThen_exception_errorVoid() {
+            //given
+            ResultVoid ok = Result.ok();
+            //when
+            ResultVoid result = ok.andThen(() -> {throw new RuntimeException();});
+            //then
+            assertThat(result.isError()).isTrue();
+        }
+
+        @Test
+        void errorVoid_andThen_returnsSelf() {
+            //given
+            ResultVoid error = Result.error(new RuntimeException());
+            //when
+            ResultVoid result = error.andThen(() -> {});
+            //then
+            assertThat(result).isSameAs(error);
+        }
+
+        @Test
+        void errorVoid_andThen_notCalled() {
+            //given
+            ResultVoid error = Result.error(new RuntimeException());
+            final AtomicBoolean called = new AtomicBoolean(false);
+            //when
+            error.andThen(() -> called.set(true));
+            //then
+            assertThat(called).isFalse();
+        }
+
+    }
+
     /**
      * These include snippets from the Javadocs and are meant to prove that the examples are valid.
      */

--- a/src/test/java/net/kemitix/mon/ResultTest.java
+++ b/src/test/java/net/kemitix/mon/ResultTest.java
@@ -528,50 +528,6 @@ class ResultTest implements WithAssertions {
     }
 
     @Nested
-    @DisplayName("invert")
-    class InvertTests {
-        @Test
-        void justOkay_whenInvert_thenOkayJust() {
-            //given
-            final Maybe<Result<Integer>> justSuccess = Maybe.just(Result.ok(1));
-            //when
-            final Result<Maybe<Integer>> result = Result.swap(justSuccess);
-            //then
-            result.match(
-                    success -> assertThat(success.toOptional()).contains(1),
-                    error -> fail("Not an error")
-            );
-        }
-
-        @Test
-        void JustError_whenInvert_isError() {
-            //given
-            final RuntimeException exception = new RuntimeException();
-            final Maybe<Result<Integer>> justError = Maybe.just(anError(exception));
-            //when
-            final Result<Maybe<Integer>> result = Result.swap(justError);
-            //then
-            result.match(
-                    success -> fail("Not a success"),
-                    error -> assertThat(error).isSameAs(exception)
-            );
-        }
-
-        @Test
-        void nothing_whenInvert_thenOkayNothing() {
-            //given
-            final Maybe<Result<Integer>> nothing = Maybe.nothing();
-            //when
-            final Result<Maybe<Integer>> result = Result.swap(nothing);
-            //then
-            result.match(
-                    success -> assertThat(success.toOptional()).isEmpty(),
-                    error -> fail("Not an error")
-            );
-        }
-    }
-
-    @Nested
     @DisplayName("use cases")
     class UseCaseTests {
         @Test

--- a/src/test/java/net/kemitix/mon/ResultTest.java
+++ b/src/test/java/net/kemitix/mon/ResultTest.java
@@ -958,122 +958,6 @@ class ResultTest implements WithAssertions {
     }
 
     @Nested
-    @DisplayName("andThen")
-    class AndThenTests {
-        @Test
-        void okay_whenAndThen_whereSuccess_isUpdatedSuccess() {
-            //given
-            final Result<Integer> ok = Result.ok(1);
-            //when
-            final Result<String> result = ok.andThen(v -> () -> "success");
-            //then
-            result.match(
-                    v -> assertThat(v).isEqualTo("success"),
-                    e -> fail("not an error"));
-        }
-
-        @Test
-        void okay_whenAndThen_whereError_isError() {
-            //given
-            final Result<Integer> ok = Result.ok(1);
-            final RuntimeException exception = new RuntimeException();
-            //when
-            final Result<Object> result = ok.andThen(v -> () -> {
-                throw exception;
-            });
-            //then
-            result.match(
-                    x -> fail("not a success"),
-                    e -> assertThat(e).isSameAs(exception));
-        }
-
-        @Test
-        void error_whereAndThen_whereSuccess_isError() {
-            //given
-            final RuntimeException exception = new RuntimeException();
-            final Result<Integer> error = anError(exception);
-            //when
-            final Result<Object> result = error.andThen(v -> () -> "success");
-            //then
-            result.match(
-                    x -> fail("not a success"),
-                    e -> assertThat(e).isSameAs(exception));
-        }
-
-        @Test
-        void error_whenAndThen_whereError_isOriginalError() {
-            //given
-            final RuntimeException exception1 = new RuntimeException();
-            final Result<Integer> error = anError(exception1);
-            //when
-            final Result<Object> result = error.andThen(v -> () -> {
-                throw new RuntimeException();
-            });
-            //then
-            result.match(
-                    x -> fail("not a success"),
-                    e -> assertThat(e).isSameAs(exception1));
-        }
-
-        @Test
-        void okayVoid_whenAndThen_whereSuccess_isUpdatedSuccess() {
-            //given
-            final ResultVoid ok = Result.ok();
-            //when
-            final ResultVoid result = ok.andThen(() -> {
-                // do nothing
-            });
-            //then
-            assertThat(result.isOkay()).isTrue();
-        }
-
-        @Test
-        void okayVoid_whenAndThen_whereError_isError() {
-            //given
-            final ResultVoid ok = Result.ok();
-            final RuntimeException exception = new RuntimeException();
-            //when
-            final ResultVoid result = ok.andThen(() -> {
-                throw exception;
-            });
-            //then
-            result.match(
-                    () -> fail("not a success"),
-                    e -> assertThat(e).isSameAs(exception));
-        }
-
-        @Test
-        void errorVoid_whereAndThen_whereSuccess_isError() {
-            //given
-            final RuntimeException exception = new RuntimeException();
-            final ResultVoid error = Result.error(exception);
-            //when
-            final ResultVoid result = error.andThen(() -> {
-                // do nothing
-            });
-            //then
-            result.match(
-                    () -> fail("not a success"),
-                    e -> assertThat(e).isSameAs(exception));
-        }
-
-        @Test
-        void errorVoid_whenAndThen_whereError_isOriginalError() {
-            //given
-            final RuntimeException exception1 = new RuntimeException();
-            final ResultVoid error = Result.error(exception1);
-            //when
-            final ResultVoid result = error.andThen(() -> {
-                throw new RuntimeException();
-            });
-            //then
-            result.match(
-                    () -> fail("not a success"),
-                    e -> assertThat(e).isSameAs(exception1));
-        }
-    }
-
-    @Nested
     @DisplayName("thenWith")
     class ThenWithTests {
         @Test
@@ -2293,7 +2177,7 @@ class ResultTest implements WithAssertions {
 
         Result<Double> businessOperation(final String fileName1, final String fileName2) {
             return readIntFromFile(fileName1)
-                    .andThen(intFromFile1 -> () -> adjustValue(intFromFile1))
+                    .map(this::adjustValue)
                     .flatMap(adjustedIntFromFile1 -> readIntFromFile(fileName2)
                             .flatMap(intFromFile2 -> adjustedIntFromFile1
                                     .flatMap(aif1 -> calculateAverage(aif1, intFromFile2))));


### PR DESCRIPTION
Removes:

- `Result.andThen(...)`
- `Result.swap(...)`